### PR TITLE
Fix llms builds with generated configuration

### DIFF
--- a/yardang/build.py
+++ b/yardang/build.py
@@ -622,8 +622,19 @@ def generate_docs_configuration(
                             fp.write("docs/html\n")
                         if not has_index_md:
                             fp.write("index.md\n")
-            # yield folder path to sphinx build
-            yield td
+            # sphinx-llm starts a nested Sphinx build without forwarding the
+            # generated configuration directory. Make the same configuration
+            # available from the source directory for that build.
+            source_configuration = Path("conf.py")
+            if use_llms:
+                source_configuration.write_text(template)
+
+            try:
+                # yield folder path to sphinx build
+                yield td
+            finally:
+                if use_llms:
+                    source_configuration.unlink(missing_ok=True)
 
 
 @contextmanager

--- a/yardang/conf.py.j2
+++ b/yardang/conf.py.j2
@@ -141,6 +141,8 @@ exclude_patterns = [
     ".DS_Store",
     "node_modules",
     "_skbuild",
+    ".venv",
+    ".venv/*",
     ".pytest_cache",
     ".github",
     ".github/*",

--- a/yardang/tests/test_all.py
+++ b/yardang/tests/test_all.py
@@ -109,6 +109,7 @@ use-autoapi = false
                 conf_content = (Path(conf_dir) / "conf.py").read_text()
                 assert '"README.md"' in conf_content
                 assert '"AGENTS.md"' in conf_content
+                assert '".venv"' in conf_content
                 assert '"docs/.jupyter_cache"' in conf_content
                 assert '"docs/html"' in conf_content
         finally:

--- a/yardang/tests/test_llms.py
+++ b/yardang/tests/test_llms.py
@@ -111,6 +111,9 @@ suffix-mode = "replace"
                 assert "llms_txt_suffix_mode" in conf_content
                 assert "replace" in conf_content
                 assert "A project for LLMs" in conf_content
+                assert Path("conf.py").read_text() == conf_content
+
+            assert not Path("conf.py").exists()
         finally:
             os.chdir(original_cwd)
 


### PR DESCRIPTION
Yardang supplies Sphinx configuration through a temporary directory. sphinx-llm starts a nested Sphinx build without forwarding that directory, so llms generation fails when a project has no checked-in conf.py.\n\nExpose the generated configuration from the source directory for the duration of llms-enabled builds, remove it afterward, and cover both behaviors with a regression test.