### PR TITLE
Improve dark-mode syntax highlighting for sphinxawesome theme

### DIFF
--- a/yardang/sphinxawesome_theme.css
+++ b/yardang/sphinxawesome_theme.css
@@ -31,3 +31,93 @@ a.reference > img {
 .copybtn {
     display: none;
 }
+
+/*
+ * Dark-mode syntax highlighting (GitHub Dark palette).
+ *
+ * yardang builds Pygments with the light "sphinx" style, whose token colors
+ * (dark blues for strings/functions/classes) are unreadable on the dark code
+ * background above. These rules override the token colors in dark mode only;
+ * the background stays the one set above.
+ */
+.dark .highlight .hll { background-color: #6e7681 }
+.dark .highlight { color: #e6edf3 }
+.dark .highlight .c { color: #8B949E; font-style: italic } /* Comment */
+.dark .highlight .err { color: #F85149 } /* Error */
+.dark .highlight .esc { color: #E6EDF3 } /* Escape */
+.dark .highlight .g { color: #E6EDF3 } /* Generic */
+.dark .highlight .k { color: #FF7B72 } /* Keyword */
+.dark .highlight .l { color: #A5D6FF } /* Literal */
+.dark .highlight .n { color: #E6EDF3 } /* Name */
+.dark .highlight .o { color: #FF7B72; font-weight: bold } /* Operator */
+.dark .highlight .x { color: #E6EDF3 } /* Other */
+.dark .highlight .p { color: #E6EDF3 } /* Punctuation */
+.dark .highlight .ch { color: #8B949E; font-style: italic } /* Comment.Hashbang */
+.dark .highlight .cm { color: #8B949E; font-style: italic } /* Comment.Multiline */
+.dark .highlight .cp { color: #8B949E; font-weight: bold; font-style: italic } /* Comment.Preproc */
+.dark .highlight .cpf { color: #8B949E; font-style: italic } /* Comment.PreprocFile */
+.dark .highlight .c1 { color: #8B949E; font-style: italic } /* Comment.Single */
+.dark .highlight .cs { color: #8B949E; font-weight: bold; font-style: italic } /* Comment.Special */
+.dark .highlight .gd { color: #FFA198; background-color: #490202 } /* Generic.Deleted */
+.dark .highlight .ge { color: #E6EDF3; font-style: italic } /* Generic.Emph */
+.dark .highlight .ges { color: #E6EDF3; font-weight: bold; font-style: italic } /* Generic.EmphStrong */
+.dark .highlight .gr { color: #FFA198 } /* Generic.Error */
+.dark .highlight .gh { color: #79C0FF; font-weight: bold } /* Generic.Heading */
+.dark .highlight .gi { color: #56D364; background-color: #0F5323 } /* Generic.Inserted */
+.dark .highlight .go { color: #8B949E } /* Generic.Output */
+.dark .highlight .gp { color: #8B949E } /* Generic.Prompt */
+.dark .highlight .gs { color: #E6EDF3; font-weight: bold } /* Generic.Strong */
+.dark .highlight .gu { color: #79C0FF } /* Generic.Subheading */
+.dark .highlight .gt { color: #FF7B72 } /* Generic.Traceback */
+.dark .highlight .g-Underline { color: #E6EDF3; text-decoration: underline } /* Generic.Underline */
+.dark .highlight .kc { color: #79C0FF } /* Keyword.Constant */
+.dark .highlight .kd { color: #FF7B72 } /* Keyword.Declaration */
+.dark .highlight .kn { color: #FF7B72 } /* Keyword.Namespace */
+.dark .highlight .kp { color: #79C0FF } /* Keyword.Pseudo */
+.dark .highlight .kr { color: #FF7B72 } /* Keyword.Reserved */
+.dark .highlight .kt { color: #FF7B72 } /* Keyword.Type */
+.dark .highlight .ld { color: #79C0FF } /* Literal.Date */
+.dark .highlight .m { color: #A5D6FF } /* Literal.Number */
+.dark .highlight .s { color: #A5D6FF } /* Literal.String */
+.dark .highlight .na { color: #E6EDF3 } /* Name.Attribute */
+.dark .highlight .nb { color: #E6EDF3 } /* Name.Builtin */
+.dark .highlight .nc { color: #F0883E; font-weight: bold } /* Name.Class */
+.dark .highlight .no { color: #79C0FF; font-weight: bold } /* Name.Constant */
+.dark .highlight .nd { color: #D2A8FF; font-weight: bold } /* Name.Decorator */
+.dark .highlight .ni { color: #FFA657 } /* Name.Entity */
+.dark .highlight .ne { color: #F0883E; font-weight: bold } /* Name.Exception */
+.dark .highlight .nf { color: #D2A8FF; font-weight: bold } /* Name.Function */
+.dark .highlight .nl { color: #79C0FF; font-weight: bold } /* Name.Label */
+.dark .highlight .nn { color: #FF7B72 } /* Name.Namespace */
+.dark .highlight .nx { color: #E6EDF3 } /* Name.Other */
+.dark .highlight .py { color: #79C0FF } /* Name.Property */
+.dark .highlight .nt { color: #7EE787 } /* Name.Tag */
+.dark .highlight .nv { color: #79C0FF } /* Name.Variable */
+.dark .highlight .ow { color: #FF7B72; font-weight: bold } /* Operator.Word */
+.dark .highlight .pm { color: #E6EDF3 } /* Punctuation.Marker */
+.dark .highlight .w { color: #6E7681 } /* Text.Whitespace */
+.dark .highlight .mb { color: #A5D6FF } /* Literal.Number.Bin */
+.dark .highlight .mf { color: #A5D6FF } /* Literal.Number.Float */
+.dark .highlight .mh { color: #A5D6FF } /* Literal.Number.Hex */
+.dark .highlight .mi { color: #A5D6FF } /* Literal.Number.Integer */
+.dark .highlight .mo { color: #A5D6FF } /* Literal.Number.Oct */
+.dark .highlight .sa { color: #79C0FF } /* Literal.String.Affix */
+.dark .highlight .sb { color: #A5D6FF } /* Literal.String.Backtick */
+.dark .highlight .sc { color: #A5D6FF } /* Literal.String.Char */
+.dark .highlight .dl { color: #79C0FF } /* Literal.String.Delimiter */
+.dark .highlight .sd { color: #A5D6FF } /* Literal.String.Doc */
+.dark .highlight .s2 { color: #A5D6FF } /* Literal.String.Double */
+.dark .highlight .se { color: #79C0FF } /* Literal.String.Escape */
+.dark .highlight .sh { color: #79C0FF } /* Literal.String.Heredoc */
+.dark .highlight .si { color: #A5D6FF } /* Literal.String.Interpol */
+.dark .highlight .sx { color: #A5D6FF } /* Literal.String.Other */
+.dark .highlight .sr { color: #79C0FF } /* Literal.String.Regex */
+.dark .highlight .s1 { color: #A5D6FF } /* Literal.String.Single */
+.dark .highlight .ss { color: #A5D6FF } /* Literal.String.Symbol */
+.dark .highlight .bp { color: #E6EDF3 } /* Name.Builtin.Pseudo */
+.dark .highlight .fm { color: #D2A8FF; font-weight: bold } /* Name.Function.Magic */
+.dark .highlight .vc { color: #79C0FF } /* Name.Variable.Class */
+.dark .highlight .vg { color: #79C0FF } /* Name.Variable.Global */
+.dark .highlight .vi { color: #79C0FF } /* Name.Variable.Instance */
+.dark .highlight .vm { color: #79C0FF } /* Name.Variable.Magic */
+.dark .highlight .il { color: #A5D6FF } /* Literal.Number.Integer.Long */


### PR DESCRIPTION
The sphinxawesome theme's dark mode was hard to read: yardang builds Pygments with the light `sphinx` style (and there is no dark variant), so on the forced `#1e2433` dark code background the dark-blue tokens (strings `#4070a0`, functions `#06287e`, classes `#0e84b5`) were low-contrast.

This adds a **GitHub Dark** token palette scoped under `.dark .highlight` in the bundled `sphinxawesome_theme.css`. Because `.dark .highlight .s1` (specificity 0,2,1) beats the light `.highlight .s1` (0,1,1), it overrides token colors in dark mode only; the code background stays `#1e2433`.
