### PR TITLE
Exclude jupyter_execute output from documentation build

### DIFF
--- a/yardang/conf.py.j2
+++ b/yardang/conf.py.j2
@@ -155,6 +155,15 @@ exclude_patterns = [
     "*.wiki/*",
     "docs/.jupyter_cache",
     "docs/.jupyter_cache/*",
+    # myst-nb writes executed notebooks into a ``jupyter_execute`` directory
+    # inside the source tree. With the source root at the project root, a
+    # rebuild would otherwise re-read that output as source and nest it deeper
+    # on every run (``jupyter_execute/.../jupyter_execute/...``). Exclude it at
+    # any depth.
+    "jupyter_execute",
+    "jupyter_execute/*",
+    "**/jupyter_execute",
+    "**/jupyter_execute/**",
     "docs/wiki",
     "docs/wiki/*",
     "docs/html",


### PR DESCRIPTION
## Summary

myst-nb writes executed notebooks into a `jupyter_execute` directory inside the source tree. Because yardang builds with the source root at the project root and `jupyter_execute` was not excluded, each rebuild re-read that output as source and nested it deeper:

```
docs/jupyter_execute/docs/jupyter_execute/docs/jupyter_execute/docs/notebooks/example
```

Eventually the build fails with a missing doctree, e.g.:

```
FileNotFoundError: .../docs/html/.doctrees/docs/jupyter_execute/docs/jupyter_execute/docs/jupyter_execute/docs/notebooks/example.doctree
```

This adds `jupyter_execute` (at any depth) to `exclude_patterns` so Sphinx never picks the executed-notebook output back up as source.

## Verification

Checked with Sphinx's own `sphinx.util.matching.Matcher`:

- Excluded: `docs/jupyter_execute/...` and arbitrarily-nested `.../jupyter_execute/.../jupyter_execute/...`
- Kept: real sources like `docs/notebooks/example` and `docs/src/configuration`

Note for existing checkouts: delete any already-nested output before rebuilding — `rm -rf docs/jupyter_execute docs/html` (both gitignored).