### PR TITLE
Support custom Sphinx extensions

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -162,6 +162,7 @@ use-autoapi = true
 
 ```toml
 [tool.yardang]
+extensions = ["your_package.sphinx"]
 html_theme_options = {}
 html_static_path = []
 html_css_files = []

--- a/yardang/build.py
+++ b/yardang/build.py
@@ -295,6 +295,7 @@ def generate_docs_configuration(
         configuration_args = {}
         for config_option, default in {
             # sphinx generic
+            "extensions": [],
             "html_theme_options": {},
             "html_static_path": [],
             "html_extra_path": [],
@@ -626,6 +627,8 @@ def generate_docs_configuration(
                             fp.write("docs/html\n")
                         if not has_index_md:
                             fp.write("index.md\n")
+            if "index.md" not in pages:
+                Path("index.md").touch(exist_ok=True)
             # sphinx-llm starts a nested Sphinx build without forwarding the
             # generated configuration directory. Make the same configuration
             # available from the source directory for that build.

--- a/yardang/conf.py.j2
+++ b/yardang/conf.py.j2
@@ -76,6 +76,7 @@ extensions = [
     "sphinxcontrib.autodoc_pydantic",
     "sphinx_reredirects",
 ]
+extensions.extend({{extensions}})
 
 # Add breathe extension if configured
 if use_breathe:

--- a/yardang/tests/test_all.py
+++ b/yardang/tests/test_all.py
@@ -156,6 +156,33 @@ use-autoapi = false
         finally:
             os.chdir(original_cwd)
 
+    def test_additional_sphinx_extensions(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "test-project"\nversion = "1.0.0"\n\n[tool.yardang]\nextensions = ["example.extension"]\n'
+        )
+        (tmp_path / "README.md").write_text("# Test Project\n\nTest content.")
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            with generate_docs_configuration() as conf_dir:
+                conf_content = (Path(conf_dir) / "conf.py").read_text()
+                assert "extensions.extend(['example.extension'])" in conf_content
+        finally:
+            os.chdir(original_cwd)
+
+    def test_build_creates_missing_master_document(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text('[project]\nname = "test-project"\nversion = "1.0.0"\n\n[tool.yardang]\nuse-autoapi = false\n')
+        (tmp_path / "README.md").write_text("# Test Project\n\nTest content.")
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            build(quiet=True, output=str(tmp_path / "html"))
+            assert (tmp_path / "html" / "index.html").is_file()
+        finally:
+            os.chdir(original_cwd)
+
 
 class TestGetConfigFlex:
     """Tests for get_config_flex accepting both hyphens and underscores."""


### PR DESCRIPTION
Allows projects using Yardang to load project-specific Sphinx extensions from pyproject.toml.

- reads an extensions list from [tool.yardang]
- appends configured extensions to Yardang's generated Sphinx configuration
- creates the generated master document before Sphinx starts a first build
- documents the new setting and covers both behaviors with tests