### PR TITLE
Add Yardang Sphinx extension

### DIFF
--- a/yardang/conf.py.j2
+++ b/yardang/conf.py.j2
@@ -65,6 +65,7 @@ use_llms = {{use_llms}}  # noqa: F821
 # BASE EXTENSIONS #
 ###################
 extensions = [
+    "yardang.sphinx",
     "myst_nb",
     "sphinx.ext.napoleon",
     "sphinx_design",

--- a/yardang/sphinx/__init__.py
+++ b/yardang/sphinx/__init__.py
@@ -1,0 +1,10 @@
+from yardang import __version__
+
+
+def setup(_app) -> dict[str, object]:
+    """Register Yardang as a Sphinx extension."""
+    return {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/yardang/tests/test_sphinx.py
+++ b/yardang/tests/test_sphinx.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from yardang import __version__
+from yardang.build import generate_docs_configuration
+from yardang.sphinx import setup
+
+
+def test_setup_returns_extension_metadata():
+    assert setup(None) == {
+        "version": __version__,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
+
+
+def test_generated_configuration_enables_extension(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "test-project"\nversion = "1.0.0"\n')
+    (tmp_path / "README.md").write_text("# Test Project\n")
+    monkeypatch.chdir(tmp_path)
+
+    with generate_docs_configuration() as conf_dir:
+        conf_content = (Path(conf_dir) / "conf.py").read_text()
+
+    assert '"yardang.sphinx"' in conf_content


### PR DESCRIPTION
## Description

Add a no-op `yardang.sphinx` extension and load it from generated Sphinx configuration. This establishes the extension namespace for later Yardang-owned integrations without moving existing hooks or changing llms generation yet.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor / code cleanup
- [ ] CI / build configuration
- [ ] Other (describe below)

## Checklist

- [x] Linting passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] New tests added for new functionality
- [ ] Documentation updated (not applicable for this no-op scaffold)
- [ ] Changelog / version bump (not applicable)
