### PR TITLE
Preserve markdown download handling

### DIFF
--- a/yardang/sphinx/llms.py
+++ b/yardang/sphinx/llms.py
@@ -76,6 +76,7 @@ class LlmsBuilder(MarkdownBuilder):
         return _target_uri(docname)
 
     def finish(self) -> None:
+        super().finish()
         docnames = list(self.env.collect_relations())
         _write_sitemap(self.app, docnames)
         _write_full_document(self.app, docnames)

--- a/yardang/tests/test_llms.py
+++ b/yardang/tests/test_llms.py
@@ -2,6 +2,8 @@ import re
 from pathlib import Path
 from subprocess import Popen
 
+from sphinx.cmd.build import build_main
+
 from yardang.build import generate_docs_configuration
 from yardang.cli import build
 
@@ -99,6 +101,20 @@ def test_full_build_can_be_disabled(tmp_path, monkeypatch):
     assert (output / "llms.txt").is_file()
     assert not (output / "llms-full.txt").exists()
     assert "llms-full.txt" not in (output / "llms.txt").read_text()
+
+
+def test_explicit_builder_copies_downloads(tmp_path, monkeypatch):
+    _write_project(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    output = tmp_path / "llms"
+
+    with generate_docs_configuration() as conf_dir:
+        result = build_main(["-q", "-b", "yardang-llms", "-c", str(conf_dir), ".", str(output)])
+
+    assert result == 0
+    download = re.search(r"\]\(([^)]*_downloads/[^)]+)\)", (output / "index.html.md").read_text())
+    assert download is not None
+    assert (output / download.group(1)).is_file()
 
 
 def test_llms_generation_is_disabled_by_default(tmp_path, monkeypatch):


### PR DESCRIPTION
Call `MarkdownBuilder.finish()` from Yardang's explicit `yardang-llms` builder so `sphinx-markdown-builder` 0.6.11 can copy referenced downloads.

Without the parent lifecycle hook, direct builder output contains `_downloads` links but omits the files. Regression coverage builds with `yardang-llms` and verifies the generated link resolves to a copied file.
